### PR TITLE
hotfix/make-input-id-more-unique

### DIFF
--- a/src/components/adopt/extraanimals/ExtraCats.astro
+++ b/src/components/adopt/extraanimals/ExtraCats.astro
@@ -87,8 +87,8 @@ const allowedOutside = {
             />
             <InputDynamicLabel
               inputType = "text"
-              inputName = "extra-cat-[CATID]-declawed"
-              inputId = "extra-cat-[CATID]-declawed"
+              inputName = "extra-cat-[CATID]-declawed-yesno"
+              inputId = "extra-cat-[CATID]-declawed-yesno"
               inputRequired = true
               labelText = "Declawed"
             />


### PR DESCRIPTION
Need a more unique name so it doesn't get mixed with 'declawed-where' when searching XPATHS.